### PR TITLE
Add meta charset and mobile friendly viewport tags

### DIFF
--- a/routes/_app.tsx
+++ b/routes/_app.tsx
@@ -7,6 +7,8 @@ export default function App({ Component }: AppProps) {
   return (
     <html data-custom="data">
       <Head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>Craig's Deno Diary</title>
         <link rel="stylesheet" href={asset("style.css")} />
         <link rel="icon" href="/favicon.ico" sizes="32x32" />


### PR DESCRIPTION
I just noticed that the viewport meta tag was likely missing from this when I was viewing the blog on my phone. I also added the charset meta tag as well. I usually put these as the first elements in the head since the charset one needs to show up within a certain amount of bytes.